### PR TITLE
Migrate jsc tsmp manual: Link updates, needs fixing

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -60,4 +60,22 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
+
+
+napoleon_numpy_docstring = True
+napoleon_use_ivar = True
+
+copybutton_prompt_text = (r">>> |\.\.\. |\$ |" +
+                          r"In \[\d*\]: | {2,5}\.\.\.: | {5,8}: ")
+copybutton_prompt_is_regexp = True
+
+html_show_sourcelink = True
+
+# MyST generates link anchors from MarkDown headings
+myst_heading_anchors = 4
+
+myst_enable_extensions = [
+    "amsmath",                  # LaTeX equations
+    "dollarmath",               # Inline LaTex
+]

--- a/doc/content/debugging.md
+++ b/doc/content/debugging.md
@@ -1,6 +1,6 @@
 # Debugging TSMP #
 
-See also [Debug Tips](build_examples.md#debug-tips) for building
+See also [Debug Tips](build_examples_tsmppdaf.md#debug-tips) for building
 TSMP!
 
 If an error appears and the source can not be localized by the default

--- a/doc/content/setup_examples.md
+++ b/doc/content/setup_examples.md
@@ -33,7 +33,7 @@ is given at
 
 The common build for the Testcase FallSchool 2019 is [Compile
 Parflow + CLM with
-PDAF](./build_examples.md#compile-parflow-and-clm-with-pdaf). Choose the
+PDAF](./build_examples_tsmppdaf.md#compile-parflow-and-clm-with-pdaf). Choose the
 correct command for your machine and, if possible, the newest version.
 
 ## CLM5 in TSMP setup: nrw_5x


### PR DESCRIPTION
Probably you may not want all of the `conf.py` settings that I have copied from the existing manual, so there would have to be some cherrypicking. But the myst-settings are needed for links to work I think.